### PR TITLE
Update symantec_av_updates

### DIFF
--- a/checks/symantec_av_updates
+++ b/checks/symantec_av_updates
@@ -23,7 +23,9 @@ def inventory_symantec_av_updates(info):
 def check_symantec_av_updates(_no_item, params, info):
     warn, crit = params
     last_text = info[0][0]
-    if '/' in last_text:
+    if " ".join(info[0]) == "Waiting for update.":
+        return 2, "SEP definition file not found.  'sav info -d' returns 'Waiting for update.'  Try running 'sav liveupdate -u'."
+    elif '/' in last_text:
         if len(last_text) == 10:
             last_broken = time.strptime(last_text, "%m/%d/%Y")
         else:


### PR DESCRIPTION
If SEP is installed, but the initial definition files have not been successfully downloaded, running "sav info -d" will return "Waiting for update." instead of a date and revision.

This condition causes the check to crash, and return "UNKN - check failed - please submit a crash report!" 

The proposed change handles this condition, so the check returns CRIT, with an error message.